### PR TITLE
CI: add workflow to build ESP32 software project

### DIFF
--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -18,11 +18,11 @@ jobs:
           cd software/components
           wget https://github.com/h2zero/esp-nimble-cpp/archive/refs/tags/1.3.1.zip
           unzip *.zip
-      - uses: actions/checkout@v3
-        with:
-          repository: espressif/esp-idf
-          path: idf-repo
-          submodules: 'recursive'
+      # - uses: actions/checkout@v3
+      #   with:
+      #     repository: espressif/esp-idf
+      #     path: idf-repo
+      #     submodules: 'recursive'
       - name: Build
         uses: espressif/esp-idf-ci-action@v1
         with:

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -2,9 +2,10 @@ name: Software Build
 on:
   push:
     branches:
-       - gha*
+      - gha*
     paths:
-       - 'software/**'
+      - 'software/**'
+      - '.github/workflows/**'
 
 jobs:
   get_date:

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -1,0 +1,34 @@
+name: Software Build
+on:
+  push:
+    branches:
+       - gha*
+    paths: 
+       - 'software/**'
+
+jobs:
+  build_mac:
+    runs-on: macos-latest
+      steps:
+        - name: Prereqs
+          run: |
+            brew install cmake ninja dfu-util
+        - name: Setup IDF
+          run: |
+            mkdir -p ~/esp
+            cd ~/esp
+            git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
+            cd ~/esp/esp-idf
+            ./install.sh esp32
+        - uses: actions/checkout@v2
+        - name: Setup NimBLE
+          run: |
+            mkdir software/components
+            cd software/components
+            wget https://github.com/h2zero/esp-nimble-cpp/archive/refs/tags/1.3.1.zip
+            unzip *.zip
+        - name: Build
+          run: |
+            . $HOME/esp/esp-idf/export.sh
+            idf.py build
+

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Setup IDF
         shell: powershell
         run: |
-          Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile esp-idf-tools-setup.exe
+          $Path="esp-idf-tools-setup.exe"
+          Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile $Path
           esp-idf-tools-setup.exe /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
           $InstallerProcess = Get-Process esp-idf-tools-setup
           Wait-Process -Id $InstallerProcess.id

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -56,21 +56,21 @@ jobs:
           . $HOME/esp/esp-idf/export.sh
           cd software
           idf.py build
-    build_win:
-      runs-on: windows-latest
-      steps:
-        - name: Setup IDF
-          shell: powershell
-          run: |
-            Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile esp-idf-tools-setup.exe
-            esp-idf-tools-setup.exe /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
-            $InstallerProcess = Get-Process esp-idf-tools-setup
-            Wait-Process -Id $InstallerProcess.id
-        # TODO setup components
-        - uses: actions/checkout@v2
-        - name: Build
-          shell: cmd
-          run: |
-            %userprofile%\Desktop\esp-idf\export.bat
-            cd software
-            idf.py build
+  build_win:
+    runs-on: windows-latest
+    steps:
+      - name: Setup IDF
+        shell: powershell
+        run: |
+          Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile esp-idf-tools-setup.exe
+          esp-idf-tools-setup.exe /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
+          $InstallerProcess = Get-Process esp-idf-tools-setup
+          Wait-Process -Id $InstallerProcess.id
+      # TODO setup components
+      - uses: actions/checkout@v2
+      - name: Build
+        shell: cmd
+        run: |
+          %userprofile%\Desktop\esp-idf\export.bat
+          cd software
+          idf.py build

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -6,13 +6,12 @@ on:
   push:
     branches:
       - main
-      - gha*
     paths:
       - 'software/**'
       - '.github/workflows/**'
 
 jobs:
-  build_linux:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -8,7 +8,27 @@ on:
       - '.github/workflows/**'
 
 jobs:
-  build_mac:
+  build_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup NimBLE
+        run: |
+          mkdir software/components
+          cd software/components
+          wget https://github.com/h2zero/esp-nimble-cpp/archive/refs/tags/1.3.1.zip
+          unzip *.zip
+      - uses: actions/checkout@v3
+        with:
+          repository: espressif/esp-idf
+          path: idf-repo
+          submodules: 'recursive'
+      - name: Build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v4.4
+          path: 'software'
+  setup_and_build_mac:
     runs-on: macos-latest
     if: false
     steps:
@@ -32,7 +52,7 @@ jobs:
           . $HOME/esp/esp-idf/export.sh
           cd software
           idf.py build
-  build_linux:
+  setup_and_build_linux:
     runs-on: ubuntu-latest
     if: false
     steps:
@@ -56,23 +76,24 @@ jobs:
           . $HOME/esp/esp-idf/export.sh
           cd software
           idf.py build
-  build_win:
-    runs-on: windows-latest
-    steps:
-      - name: Setup IDF
-        shell: powershell
-        run: |
-          $Cwd = Get-Location
-          $Path="$Cwd\esp-idf-tools-setup.exe"
-          Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile $Path
-          & "$Path" /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
-          $InstallerProcess = Get-Process esp-idf-tools-setup
-          Wait-Process -Id $InstallerProcess.id
-      # TODO setup components
-      - uses: actions/checkout@v2
-      - name: Build
-        shell: cmd
-        run: |
-          %userprofile%\Desktop\esp-idf\export.bat
-          cd software
-          idf.py build
+  # # This job never completed - TODO figure out what went wrong
+  # build_win:
+  #   runs-on: windows-latest
+  #   steps:
+  #     - name: Setup IDF
+  #       shell: powershell
+  #       run: |
+  #         $Cwd = Get-Location
+  #         $Path="$Cwd\esp-idf-tools-setup.exe"
+  #         Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile $Path
+  #         & "$Path" /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
+  #         $InstallerProcess = Get-Process esp-idf-tools-setup
+  #         Wait-Process -Id $InstallerProcess.id
+  #     # TODO setup components
+  #     - uses: actions/checkout@v2
+  #     - name: Build
+  #       shell: cmd
+  #       run: |
+  #         %userprofile%\Desktop\esp-idf\export.bat
+  #         cd software
+  #         idf.py build

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -65,8 +65,7 @@ jobs:
           $Cwd = Get-Location
           $Path="$Cwd\esp-idf-tools-setup.exe"
           Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile $Path
-          $Cmd = '$Path /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL'
-          Invoke-Expression $Cmd
+          & "$Path" /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
           $InstallerProcess = Get-Process esp-idf-tools-setup
           Wait-Process -Id $InstallerProcess.id
       # TODO setup components

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Setup IDF
         shell: powershell
         run: |
-          $Path="esp-idf-tools-setup.exe"
+          $Cwd = Get-Location
+          $Path="$Cwd\esp-idf-tools-setup.exe"
           Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile $Path
           esp-idf-tools-setup.exe /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
           $InstallerProcess = Get-Process esp-idf-tools-setup

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -10,12 +10,11 @@ on:
 jobs:
   build_mac:
     runs-on: macos-latest
+    if: false
     steps:
-      - name: Prereqs
-        run: |
-          brew install cmake ninja dfu-util
       - name: Setup IDF
         run: |
+          brew install cmake ninja dfu-util
           mkdir -p ~/esp
           cd ~/esp
           git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
@@ -35,12 +34,11 @@ jobs:
           idf.py build
   build_linux:
     runs-on: ubuntu-latest
+    if: false
     steps:
-      - name: Prereqs
-        run: |
-          sudo apt-get install git wget flex bison gperf python3 python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0
       - name: Setup IDF
         run: |
+          sudo apt-get install git wget flex bison gperf python3 python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0
           mkdir -p ~/esp
           cd ~/esp
           git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
@@ -58,3 +56,21 @@ jobs:
           . $HOME/esp/esp-idf/export.sh
           cd software
           idf.py build
+    build_win:
+      runs-on: windows-latest
+      steps:
+        - name: Setup IDF
+          shell: powershell
+          run: |
+            Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile esp-idf-tools-setup.exe
+            esp-idf-tools-setup.exe /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
+            $InstallerProcess = Get-Process esp-idf-tools-setup
+            Wait-Process -Id $InstallerProcess.id
+        # TODO setup components
+        - uses: actions/checkout@v2
+        - name: Build
+          shell: cmd
+          run: |
+            %userprofile%\Desktop\esp-idf\export.bat
+            cd software
+            idf.py build

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -1,7 +1,11 @@
 name: Software Build
 on:
+  schedule:
+    - cron: '0 15 * * *'  # 8AM Pacific; daily
+  workflow_dispatch:
   push:
     branches:
+      - main
       - gha*
     paths:
       - 'software/**'
@@ -18,11 +22,6 @@ jobs:
           cd software/components
           wget https://github.com/h2zero/esp-nimble-cpp/archive/refs/tags/1.3.1.zip
           unzip *.zip
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: espressif/esp-idf
-      #     path: idf-repo
-      #     submodules: 'recursive'
       - name: Build
         uses: espressif/esp-idf-ci-action@v1
         with:
@@ -30,7 +29,6 @@ jobs:
           path: 'software'
   setup_and_build_mac:
     runs-on: macos-latest
-    if: false
     steps:
       - name: Setup IDF
         run: |
@@ -54,7 +52,6 @@ jobs:
           idf.py build
   setup_and_build_linux:
     runs-on: ubuntu-latest
-    if: false
     steps:
       - name: Setup IDF
         run: |

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -65,7 +65,8 @@ jobs:
           $Cwd = Get-Location
           $Path="$Cwd\esp-idf-tools-setup.exe"
           Invoke-WebRequest -URI https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-online-2.16.exe -OutFile $Path
-          esp-idf-tools-setup.exe /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL
+          $Cmd = '$Path /VERYSILENT /SUPPRESSMSGBOXES /SP- /NOCANCEL'
+          Invoke-Expression $Cmd
           $InstallerProcess = Get-Process esp-idf-tools-setup
           Wait-Process -Id $InstallerProcess.id
       # TODO setup components

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -3,32 +3,36 @@ on:
   push:
     branches:
        - gha*
-    paths: 
+    paths:
        - 'software/**'
 
 jobs:
+  get_date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Testing
+        run: echo TEST
   build_mac:
     runs-on: macos-latest
-      steps:
-        - name: Prereqs
-          run: |
-            brew install cmake ninja dfu-util
-        - name: Setup IDF
-          run: |
-            mkdir -p ~/esp
-            cd ~/esp
-            git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
-            cd ~/esp/esp-idf
-            ./install.sh esp32
-        - uses: actions/checkout@v2
-        - name: Setup NimBLE
-          run: |
-            mkdir software/components
-            cd software/components
-            wget https://github.com/h2zero/esp-nimble-cpp/archive/refs/tags/1.3.1.zip
-            unzip *.zip
-        - name: Build
-          run: |
-            . $HOME/esp/esp-idf/export.sh
-            idf.py build
-
+    steps:
+      - name: Prereqs
+        run: |
+          brew install cmake ninja dfu-util
+      - name: Setup IDF
+        run: |
+          mkdir -p ~/esp
+          cd ~/esp
+          git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
+          cd ~/esp/esp-idf
+          ./install.sh esp32
+      - uses: actions/checkout@v2
+      - name: Setup NimBLE
+        run: |
+          mkdir software/components
+          cd software/components
+          wget https://github.com/h2zero/esp-nimble-cpp/archive/refs/tags/1.3.1.zip
+          unzip *.zip
+      - name: Build
+        run: |
+          . $HOME/esp/esp-idf/export.sh
+          idf.py build

--- a/.github/workflows/software_build.yml
+++ b/.github/workflows/software_build.yml
@@ -8,11 +8,6 @@ on:
       - '.github/workflows/**'
 
 jobs:
-  get_date:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Testing
-        run: echo TEST
   build_mac:
     runs-on: macos-latest
     steps:
@@ -25,7 +20,7 @@ jobs:
           cd ~/esp
           git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
           cd ~/esp/esp-idf
-          ./install.sh esp32
+          ./install.sh esp32 > install_logs
       - uses: actions/checkout@v2
       - name: Setup NimBLE
         run: |
@@ -36,4 +31,30 @@ jobs:
       - name: Build
         run: |
           . $HOME/esp/esp-idf/export.sh
+          cd software
+          idf.py build
+  build_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prereqs
+        run: |
+          sudo apt-get install git wget flex bison gperf python3 python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0
+      - name: Setup IDF
+        run: |
+          mkdir -p ~/esp
+          cd ~/esp
+          git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
+          cd ~/esp/esp-idf
+          ./install.sh esp32 > install_logs
+      - uses: actions/checkout@v2
+      - name: Setup NimBLE
+        run: |
+          mkdir software/components
+          cd software/components
+          wget https://github.com/h2zero/esp-nimble-cpp/archive/refs/tags/1.3.1.zip
+          unzip *.zip
+      - name: Build
+        run: |
+          . $HOME/esp/esp-idf/export.sh
+          cd software
           idf.py build


### PR DESCRIPTION
Add new GitHub Actions workflow that:
* Builds the ESP32 software project
* Performs full IDF setup and project building on Linux and Mac
